### PR TITLE
refactor(commands): rewrite pj command

### DIFF
--- a/commands/pj.js
+++ b/commands/pj.js
@@ -2,147 +2,98 @@ const Discord = require('discord.js');
 const config = require('../config.json');
 const blizzard = require('blizzard.js').initialize({ apikey: config.blizzapi });
 exports.run = (client, message, args) => {
-    
+
     if (args.length != 3){
       message.channel.send('Wrong input, type ?help for help!')
       return;
     };
 
-    let name = args[0];
-    let server = args[1];
-    let region = args[2];
+    let [name, server, region] = args;
+    let classes = {
+        1: 'Warrior',
+        2: 'Paladin',
+        3: 'Hunter',
+        4: 'Rogue',
+        5: 'Priest',
+        6: 'Death Knight',
+        7: 'Shaman',
+        8: 'Mage',
+        9: 'Warlock',
+        10: 'Monk',
+        11: 'Druid',
+        12: 'Demon Hunter',
+    };
+    let races = {
+        1: 'Human',
+        2: 'Orc',
+        3: 'Dwarf',
+        4: 'Night Elf',
+        5: 'Undead',
+        6: 'Tauren',
+        7: 'Gnome',
+        8: 'Troll',
+        9: 'Goblin',
+        10: 'Blood Elf',
+        11: 'Draeni',
+        22: 'Worgen',
+        25: 'Pandaren',
+        26: 'Pandaren',
+    };
 
-    blizzard.wow.character(['profile', 'guild', 'items'], { origin: region, realm: server, name: name })
-    .then(response => {
+    blizzard.wow.character(
+        ['profile', 'guild', 'items'],
+        { origin: region, realm: server, name }
+    ).then(response => {
+        let color;
+        let guildname;
         let respuesta = response.data;
+        // class is a reserved keyword in JavaScript
+        let [clss, race] = [ respuesta.class, respuesta.race ];
     
         // Para determinar y asignar el nombre de la clase.
-        switch (respuesta['class']){
-            case 1:
-                respuesta['class'] = 'Warrior';
-                break;
-            case 2:
-                respuesta['class'] = 'Paladin';
-                break;
-            case 3:
-                respuesta['class'] = 'Hunter';
-                break;
-            case 4:
-                respuesta['class'] = 'Rogue';
-                break;
-            case 5:
-                respuesta['class'] = 'Priest';
-                break;
-            case 6:
-                respuesta['class'] = 'Death Knight';
-                break;
-            case 7:
-                respuesta['class'] = 'Shaman';
-                break;
-            case 8:
-                respuesta['class'] = 'Mage';
-                break;
-            case 9:
-                respuesta['class'] = 'Warlock';
-                break;
-            case 10:
-                respuesta['class'] = 'Monk';
-                break;
-            case 11:
-                respuesta['class'] = 'Druid';
-                break;
-            case 12:
-                respuesta['class'] = 'Demon Hunter';
-                break;
-        };
+        respuesta.class = classes[clss];
 
-    // Para determinar la raza.
-        switch (respuesta['race']){
-            case 1:
-                respuesta['race'] = 'Human';
-                break;
-            case 2:
-                respuesta['race'] = 'Orc';
-                break;
-            case 3:
-                respuesta['race'] = 'Dwarf';
-                break;
-            case 4:
-                respuesta['race'] = 'Night Elf';
-                break;
-            case 5:
-                respuesta['race'] = 'Undead';
-                break;
-            case 6:
-                respuesta['race'] = 'Tauren';
-                break;
-            case 7:
-                respuesta['race'] = 'Gnome';
-                break;
-            case 8:
-                respuesta['race'] = 'Troll';
-                break;
-            case 9:
-                respuesta['race'] = 'Goblin';
-                break;
-            case 10:
-                respuesta['race'] = 'Blood Elf';
-                break;
-            case 11:
-                respuesta['race'] = 'Draenei'
-                break;
-            case 22:
-                respuesta['race'] = 'Worgen';
-                break;
-            case 25:
-                respuesta['race'] = 'Pandaren';
-                break;
-            case 26:
-                respuesta['race'] = 'Pandaren';
-                break;
-        };
+        // Para determinar la raza.
+        respuesta.race = races[race];
     
-        // Para deterimar la facción:
-        let color;
-        if (respuesta['faction'] == 0) {
-            respuesta['faction'] = 'Alliance';
+        // Para determinar la facción:
+        if (respuesta.faction == 0) {
+            respuesta.faction = 'Alliance';
             color = '#1560d8';
-        }else{
-            respuesta['faction'] = 'Horde';
+        } else {
+            respuesta.faction = 'Horde';
             color = '#b71b1b';
         };
         
         //  Para determinar género.
-        if (respuesta['gender'] == 0){
-            respuesta['gender'] = '&#9794';
-        }else{
-            respuesta['gender'] = '&#9792;';
+        if (respuesta.gender == 0) {
+            respuesta.gender = '&#9794';
+        } else {
+            respuesta.gender = '&#9792;';
         };
 
         // No guild error handle.
-        let guildname;
-        if (respuesta['guild'] == undefined){
-            guildname = respuesta['name'] + ' hasn\'t joined a guild yet';
-        }else{
-            guildname = respuesta['guild'].name;
+        if (respuesta.guild == undefined) {
+            guildname = `${respuesta.name} hasn't joined a guild yet`;
+        } else {
+            guildname = respuesta.guild.name;
         }
         
         // No ilvl error handle.
-        if (respuesta['items'].averageItemLevelEquipped == undefined) {
-            respuesta['items'].averageItemLevelEquipped = 'No ilvl info at the moment';
+        if (respuesta.items.averageItemLevelEquipped == undefined) {
+            respuesta.items.averageItemLevelEquipped = 'No ilvl info at the moment';
         };
 
-        console.log(respuesta['name']);
+        console.log(respuesta.name);
 
         const embed = new Discord.RichEmbed()
             .setColor(color)
-            .setThumbnail('http://render-api-' + region + '.worldofwarcraft.com/static-render/' + region + '/' + respuesta['thumbnail'])
-            .addField(respuesta['name'] + ', level ' + respuesta['level'] + ' ' + respuesta['race'] + ' ' + respuesta['class'], '[Armory page.](https://worldofwarcraft.com/character/'+server+'/'+name+')')
-            .addField('Equipped ilvl:', respuesta['items'].averageItemLevelEquipped, true)
-            .addField('Faction:', respuesta['faction'],true)
+            .setThumbnail(`http://render-api-${region}.worldofwarcraft.com/static-render/${region}/${respuesta.thumbnail}`)
+            .addField(`${respuesta.name}, level ${respuesta.level} ${respuesta.race} ${respuesta.class}`, `[Armory page.](https://worldofwarcraft.com/character/${server}/${name})`)
+            .addField('Equipped ilvl:', respuesta.items.averageItemLevelEquipped, true)
+            .addField('Faction:', respuesta.faction, true)
             .addField('Guild:', guildname, true)
 
         message.channel.send({embed});
-
     });
 };

--- a/commands/pj.js
+++ b/commands/pj.js
@@ -8,8 +8,8 @@ exports.run = (client, message, args) => {
       return;
     };
 
-    let [name, server, region] = args;
-    let classes = {
+    const [name, server, region] = args;
+    const classes = {
         1: 'Warrior',
         2: 'Paladin',
         3: 'Hunter',
@@ -23,7 +23,7 @@ exports.run = (client, message, args) => {
         11: 'Druid',
         12: 'Demon Hunter',
     };
-    let races = {
+    const races = {
         1: 'Human',
         2: 'Orc',
         3: 'Dwarf',
@@ -48,7 +48,7 @@ exports.run = (client, message, args) => {
         let guildname;
         let respuesta = response.data;
         // class is a reserved keyword in JavaScript
-        let [clss, race] = [ respuesta.class, respuesta.race ];
+        const [clss, race] = [ respuesta.class, respuesta.race ];
     
         // Para determinar y asignar el nombre de la clase.
         respuesta.class = classes[clss];


### PR DESCRIPTION
Now `pj.js` it's a little less verbose, more readable and maintainable.

Apart from being more readable, using a mapping object is even a little more performant than the `switch` alternative. You can see a benchmark [here](http://jsben.ch/#/o0UDx). In any case, even if not, just the improvement in readibility justifies the change by itself.

I applied a few bits from ES6, but I think it's fairly easy to understand. If you need, feel free to ask anything. 
Probably I could improve it a bit, but, for that, I should know more about Discord, and all that :þ. 
For a quick edit, I think it's OK :). I couldn't even test if this works properly (but it should), so try it before anything. And tell me if there is any problem ;).